### PR TITLE
Remove empty references from templates

### DIFF
--- a/bin/html-to-md.php
+++ b/bin/html-to-md.php
@@ -57,6 +57,8 @@ function get_target_dir(): string {
 $target = get_target_dir();
 $files = getDirContents($target);
 
+$newFiles = [];
+
 foreach ($files as $file) {
     echo sprintf('Processing %s...', $file);
     $content = file_get_contents($file);
@@ -67,5 +69,15 @@ foreach ($files as $file) {
     file_put_contents($file, $content);
     $mdFilePath = preg_replace('/\.html$/', '.md', $file);
     rename($file, $mdFilePath);
+	$newFiles[] = $mdFilePath;
 	echo 'DONE' . PHP_EOL;
+}
+
+$empty_file_markdown_comment = "[//]: # (Empty file)";
+foreach ($newFiles as $file) {
+	if (strpos(file_get_contents($file), $empty_file_markdown_comment) !== false) {
+		echo sprintf( 'Empty file found - deleting %s...', $file );
+		unlink( $file );
+		echo 'DONE' . PHP_EOL;
+	}
 }

--- a/bin/html-to-md.php
+++ b/bin/html-to-md.php
@@ -63,6 +63,12 @@ foreach ($files as $file) {
     echo sprintf('Processing %s...', $file);
     $content = file_get_contents($file);
     // .html)
+	if (empty(trim($content))) {
+		echo 'Empty file. Deleting...';
+		unlink( $file );
+		echo 'DONE' . PHP_EOL;
+		continue;
+	}
     $content = str_replace('.html)', '.md)', $content);
     // .html#property_id)
     $content = preg_replace('/\.html(\#[\w\_]+)\)/', '.md$1)', $content);
@@ -71,13 +77,4 @@ foreach ($files as $file) {
     rename($file, $mdFilePath);
 	$newFiles[] = $mdFilePath;
 	echo 'DONE' . PHP_EOL;
-}
-
-foreach ($newFiles as $file) {
-	$content = trim(file_get_contents($file));
-	if (empty($content)) {
-		echo sprintf( 'Empty file found - deleting %s...', $file );
-		unlink( $file );
-		echo 'DONE' . PHP_EOL;
-	}
 }

--- a/bin/html-to-md.php
+++ b/bin/html-to-md.php
@@ -57,8 +57,6 @@ function get_target_dir(): string {
 $target = get_target_dir();
 $files = getDirContents($target);
 
-$newFiles = [];
-
 foreach ($files as $file) {
     echo sprintf('Processing %s...', $file);
     $content = file_get_contents($file);
@@ -75,6 +73,5 @@ foreach ($files as $file) {
     file_put_contents($file, $content);
     $mdFilePath = preg_replace('/\.html$/', '.md', $file);
     rename($file, $mdFilePath);
-	$newFiles[] = $mdFilePath;
 	echo 'DONE' . PHP_EOL;
 }

--- a/bin/html-to-md.php
+++ b/bin/html-to-md.php
@@ -73,9 +73,9 @@ foreach ($files as $file) {
 	echo 'DONE' . PHP_EOL;
 }
 
-$empty_file_markdown_comment = "[//]: # (Empty file)";
 foreach ($newFiles as $file) {
-	if (strpos(file_get_contents($file), $empty_file_markdown_comment) !== false) {
+	$content = trim(file_get_contents($file));
+	if (empty($content)) {
 		echo sprintf( 'Empty file found - deleting %s...', $file );
 		unlink( $file );
 		echo 'DONE' . PHP_EOL;

--- a/data/templates/markdown/class.md.twig
+++ b/data/templates/markdown/class.md.twig
@@ -66,13 +66,13 @@
 ### Details
 
 * File: [{{ node.path }}]({{ '../' ~ path(node.file) }})
-{% for interface in node.interfaces if interface.methods|length > 0 %}
+{% for interface in node.interfaces if (interface.getMethods is defined and methods(interface)|length > 0) or (interface.getConstants is defined and constants(interface)|length > 0) %}
 {% if loop.first %}
 * Implements:
 {% endif %}
   * [{{ interface }}]({{ link(interface) }})
 {% endfor %}
-{% for trait in node.usedTraits if trait.methods|length > 0 %}
+{% for trait in node.usedTraits if (trait.getMethods is defined and methods(trait)|length > 0) or (trait.getConstants is defined and constants(trait)|length > 0) %}
 {% if loop.first %}
 * Uses Traits:
 {% endif %}

--- a/data/templates/markdown/class.md.twig
+++ b/data/templates/markdown/class.md.twig
@@ -66,13 +66,13 @@
 ### Details
 
 * File: [{{ node.path }}]({{ '../' ~ path(node.file) }})
-{% for interface in node.interfaces %}
+{% for interface in node.interfaces if interface.methods|length > 0 %}
 {% if loop.first %}
 * Implements:
 {% endif %}
   * [{{ interface }}]({{ link(interface) }})
 {% endfor %}
-{% for trait in node.usedTraits %}
+{% for trait in node.usedTraits if trait.methods|length > 0 %}
 {% if loop.first %}
 * Uses Traits:
 {% endif %}

--- a/data/templates/markdown/elements/table-of-contents.md.twig
+++ b/data/templates/markdown/elements/table-of-contents.md.twig
@@ -1,21 +1,13 @@
 {% block table_of_contents %}
 {% set url_base = (url_base) ? url_base : '../' %}
-{% set non_empty_namespaces = [] %}
-{% if node.children|length > 0 %}
-{% for namespace in node.children|sort_asc %}
-{% if ( namespace.children|length > 0 ) or ( namespace.traits|length > 0 ) or ( namespace.interfaces|length > 0 ) or ( namespace.classes|length > 0 ) or ( constants(namespace)|length > 0 ) or ( namespace.functions|length > 0 ) %}
-{% set non_empty_namespaces = non_empty_namespaces|merge([namespace]) %}
-{% endif %}
-{% endfor %}
-{% endif %}
-{% if non_empty_namespaces|length > 0 %}
+{% for namespace in node.children if ( ( namespace.children|length > 0 ) or ( namespace.traits|length > 0 ) or ( namespace.interfaces|length > 0 ) or ( namespace.classes|length > 0 ) or ( constants(namespace)|length > 0 ) or ( namespace.functions|length > 0 ) ) %}
+{% if loop.first %}
 
 ### Namespaces
 
-{% for namespace in non_empty_namespaces %}
+{% endif %}
 * [{{ namespace }}]({{ url_base ~ namespace|route('url')|raw }})
 {% endfor %}
-{% endif %}
 {% if node.traits|length > 0 %}
 
 ### Traits

--- a/data/templates/markdown/elements/table-of-contents.md.twig
+++ b/data/templates/markdown/elements/table-of-contents.md.twig
@@ -3,7 +3,7 @@
 {% set non_empty_namespaces = [] %}
 {% if node.children|length > 0 %}
 {% for namespace in node.children|sort_asc %}
-{% if ( namespace.children|length > 0 ) or ( namespace.traits|length > 0 ) or ( namespace.interfaces|length > 0 ) or ( namespace.classes|length > 0 ) or ( namespace.constants|length > 0 ) or ( namespace.functions|length > 0 ) %}
+{% if ( namespace.children|length > 0 ) or ( namespace.traits|length > 0 ) or ( namespace.interfaces|length > 0 ) or ( namespace.classes|length > 0 ) or ( constants(namespace)|length > 0 ) or ( namespace.functions|length > 0 ) %}
 {% set non_empty_namespaces = non_empty_namespaces|merge([namespace]) %}
 {% endif %}
 {% endfor %}

--- a/data/templates/markdown/elements/table-of-contents.md.twig
+++ b/data/templates/markdown/elements/table-of-contents.md.twig
@@ -1,10 +1,18 @@
 {% block table_of_contents %}
 {% set url_base = (url_base) ? url_base : '../' %}
+{% set non_empty_namespaces = [] %}
 {% if node.children|length > 0 %}
+{% for namespace in node.children|sort_asc %}
+{% if ( namespace.children|length > 0 ) or ( namespace.traits|length > 0 ) or ( namespace.interfaces|length > 0 ) or ( namespace.classes|length > 0 ) or ( namespace.constants|length > 0 ) or ( namespace.functions|length > 0 ) %}
+{% set non_empty_namespaces = non_empty_namespaces|merge([namespace]) %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if non_empty_namespaces|length > 0 %}
 
 ### Namespaces
 
-{% for namespace in node.children|sort_asc %}
+{% for namespace in non_empty_namespaces %}
 * [{{ namespace }}]({{ url_base ~ namespace|route('url')|raw }})
 {% endfor %}
 {% endif %}

--- a/data/templates/markdown/layout.md.twig
+++ b/data/templates/markdown/layout.md.twig
@@ -3,7 +3,8 @@
 {% use 'elements/property.md.twig' %}
 {% use 'elements/method.md.twig' %}
 {% import 'base/macros.md.twig' as macros %}
-# {% block title %}{{ macros.buildNamespaceBreadcrumb(node)|spaceless|replace({"\n": "", "\r": "", "\t": ""}) }}{% endblock %}
+{% block title_heading %}{{'# '}}{% endblock %}
+{% block title %}{{ macros.buildNamespaceBreadcrumb(node)|spaceless|replace({"\n": "", "\r": "", "\t": ""}) }}{% endblock %}
 
 {% block content %}{% endblock %}
 {% block footer %}{% endblock %}

--- a/data/templates/markdown/namespace.md.twig
+++ b/data/templates/markdown/namespace.md.twig
@@ -1,5 +1,5 @@
 {% extends './layout.md.twig' %}
-{% set not_empty = ( node.children|length != 0 ) or ( node.traits|length != 0 ) or ( node.interfaces|length != 0 ) or ( node.classes|length != 0 ) or ( node.constants|length != 0 ) or ( node.functions|length != 0 ) or ( node.methods|length != 0 ) %}
+{% set not_empty = ( node.children|length != 0 ) or ( node.traits|length != 0 ) or ( node.interfaces|length != 0 ) or ( node.classes|length != 0 ) or ( constants(node)|length != 0 ) or ( node.functions|length != 0 ) or ( methods(node)|length != 0 ) %}
 
 {% block title_heading %}
 {%- if not_empty -%}

--- a/data/templates/markdown/namespace.md.twig
+++ b/data/templates/markdown/namespace.md.twig
@@ -1,4 +1,7 @@
 {% extends './layout.md.twig' %}
 {% block content %}
 {{ block('table_of_contents') -}}
+{% if ( node.children|length == 0 ) and ( node.traits|length == 0 ) and ( node.interfaces|length == 0 ) and ( node.classes|length == 0 ) and ( node.constants|length == 0 ) and ( node.functions|length == 0 ) %}
+[//]: # (Empty file)
+{% endif %}
 {% endblock %}

--- a/data/templates/markdown/namespace.md.twig
+++ b/data/templates/markdown/namespace.md.twig
@@ -1,7 +1,20 @@
 {% extends './layout.md.twig' %}
+{% set not_empty = ( node.children|length != 0 ) or ( node.traits|length != 0 ) or ( node.interfaces|length != 0 ) or ( node.classes|length != 0 ) or ( node.constants|length != 0 ) or ( node.functions|length != 0 ) or ( node.methods|length != 0 ) %}
+
+{% block title_heading %}
+{%- if not_empty -%}
+{{ parent() }}
+{%- endif -%}
+{% endblock %}
+
+{% block title %}
+{%- if not_empty -%}
+{{ parent() }}
+{%- endif -%}
+{% endblock %}
+
 {% block content %}
+{% if not_empty %}
 {{ block('table_of_contents') -}}
-{% if ( node.children|length == 0 ) and ( node.traits|length == 0 ) and ( node.interfaces|length == 0 ) and ( node.classes|length == 0 ) and ( node.constants|length == 0 ) and ( node.functions|length == 0 ) %}
-[//]: # (Empty file)
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Changes the template to remove all empty interfaces, traits, and namespaces. 
We consider these as "empty" when there's no method exposed for the Twig writer used in phpdocumentor.

It removes the sections and marks docs with a comment, so the script that runs after can clean up the marked files.