### PR TITLE
Add conditional blocks and different layout for reports

### DIFF
--- a/data/templates/markdown/layout.md.twig
+++ b/data/templates/markdown/layout.md.twig
@@ -3,8 +3,10 @@
 {% use 'elements/property.md.twig' %}
 {% use 'elements/method.md.twig' %}
 {% import 'base/macros.md.twig' as macros %}
+{% if ( node.children|length != 0 ) or ( node.traits|length != 0 ) or ( node.interfaces|length != 0 ) or ( node.classes|length != 0 ) or ( node.constants|length != 0 ) or ( node.functions|length != 0 )  or ( node.methods|length != 0 )%}
 {% block title_heading %}{{'# '}}{% endblock %}
 {% block title %}{{ macros.buildNamespaceBreadcrumb(node)|spaceless|replace({"\n": "", "\r": "", "\t": ""}) }}{% endblock %}
 
 {% block content %}{% endblock %}
 {% block footer %}{% endblock %}
+{% endif %}

--- a/data/templates/markdown/layout.md.twig
+++ b/data/templates/markdown/layout.md.twig
@@ -3,7 +3,7 @@
 {% use 'elements/property.md.twig' %}
 {% use 'elements/method.md.twig' %}
 {% import 'base/macros.md.twig' as macros %}
-{% if ( node.children|length != 0 ) or ( node.traits|length != 0 ) or ( node.interfaces|length != 0 ) or ( node.classes|length != 0 ) or ( node.constants|length != 0 ) or ( node.functions|length != 0 )  or ( node.methods|length != 0 )%}
+{% if ( node.children|length != 0 ) or ( node.traits|length != 0 ) or ( node.interfaces|length != 0 ) or ( node.classes|length != 0 ) or ( node.getConstants is defined and constants(node)|length != 0 ) or ( node.functions|length != 0 )  or ( node.getMethods is defined and methods(node)|length != 0 )%}
 {% block title_heading %}{{'# '}}{% endblock %}
 {% block title %}{{ macros.buildNamespaceBreadcrumb(node)|spaceless|replace({"\n": "", "\r": "", "\t": ""}) }}{% endblock %}
 

--- a/data/templates/markdown/namespace.md.twig
+++ b/data/templates/markdown/namespace.md.twig
@@ -1,20 +1,4 @@
 {% extends './layout.md.twig' %}
-{% set not_empty = ( node.children|length != 0 ) or ( node.traits|length != 0 ) or ( node.interfaces|length != 0 ) or ( node.classes|length != 0 ) or ( constants(node)|length != 0 ) or ( node.functions|length != 0 ) or ( methods(node)|length != 0 ) %}
-
-{% block title_heading %}
-{%- if not_empty -%}
-{{ parent() }}
-{%- endif -%}
-{% endblock %}
-
-{% block title %}
-{%- if not_empty -%}
-{{ parent() }}
-{%- endif -%}
-{% endblock %}
-
 {% block content %}
-{% if not_empty %}
 {{ block('table_of_contents') -}}
-{% endif %}
 {% endblock %}

--- a/data/templates/markdown/reports-layout.md.twig
+++ b/data/templates/markdown/reports-layout.md.twig
@@ -1,0 +1,10 @@
+{% use 'elements/table-of-contents.md.twig' %}
+{% use 'elements/constant.md.twig' %}
+{% use 'elements/property.md.twig' %}
+{% use 'elements/method.md.twig' %}
+{% import 'base/macros.md.twig' as macros %}
+{% block title_heading %}{{'# '}}{% endblock %}
+{% block title %}{{ macros.buildNamespaceBreadcrumb(node)|spaceless|replace({"\n": "", "\r": "", "\t": ""}) }}{% endblock %}
+
+{% block content %}{% endblock %}
+{% block footer %}{% endblock %}

--- a/data/templates/markdown/reports/deprecated.md.twig
+++ b/data/templates/markdown/reports/deprecated.md.twig
@@ -1,4 +1,4 @@
-{% extends 'layout.md.twig' %}
+{% extends 'reports-layout.md.twig' %}
 {% block title %}{{ project.title }}Deprecated Elements{% endblock %}
 {% block content %}
 {% set deprecatedCount = 0 %}

--- a/data/templates/markdown/reports/errors.md.twig
+++ b/data/templates/markdown/reports/errors.md.twig
@@ -1,4 +1,4 @@
-{% extends 'layout.md.twig' %}
+{% extends 'reports-layout.md.twig' %}
 {% block title %}{{ project.title }}Compilation Errors{% endblock %}
 {% block content %}
 {% set errorCount = 0 %}

--- a/data/templates/markdown/reports/markers.md.twig
+++ b/data/templates/markdown/reports/markers.md.twig
@@ -1,4 +1,4 @@
-{% extends 'layout.md.twig' %}
+{% extends 'reports-layout.md.twig' %}
 {% block title %}{{ project.title }}Markers{% endblock %}
 {% block content %}
 {% set markerCount = 0 %}


### PR DESCRIPTION
### Changes:

- Adds a different layout for report files
  - Errors, deprecations, and markers now have their own template file.
- Adds conditional blocks for the standard layout file
  -  Blocks will only be rendered if the class has visible members according to `phpdoc.xml` config