### PR TITLE
Remove empty interfaces and traits from table of contents

### DIFF
--- a/data/templates/markdown/elements/table-of-contents.md.twig
+++ b/data/templates/markdown/elements/table-of-contents.md.twig
@@ -9,22 +9,27 @@
 * [{{ namespace }}]({{ url_base ~ namespace|route('url')|raw }})
 {% endfor %}
 {% if node.traits|length > 0 %}
+{% for trait in node.traits|sort_asc if if (trait.getMethods is defined and methods(trait)|length > 0) or (trait.getConstants is defined and constants(trait)|length > 0) %}
+{% if loop.first %}
 
 ### Traits
 
 | Name | Summary |
 |------|---------|
-{% for trait in node.traits|sort_asc %}
+{% endif %}
 | [{{ trait }}]({{ url_base ~ trait|route('url')|raw }}) | {{ trait.summary }} |
 {% endfor %}
 {% endif %}
 {% if node.interfaces|length > 0 %}
+{% for interface in node.interfaces|sort_asc if (interface.getMethods is defined and methods(interface)|length > 0) or (interface.getConstants is defined and constants(interface)|length > 0) %}
+{% if loop.first %}
+
 
 ### Interfaces
 
 | Name | Summary |
 |------|---------|
-{% for interface in node.interfaces|sort_asc %}
+{% endif %}
 | [{{ interface }}]({{ url_base ~ interface|route('url')|raw }}) | {{ interface.summary }} |
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Remove the missing references to empty interfaces and traits left in the `table-of-contents.md.twig` file.
The check performed is the same as in the other files - `methods()` and `constants()` are called for both traits and interfaces. 
If none is returned, then we consider it empty. Otherwise, we render it normally.